### PR TITLE
remove throw of error, when no public Deck, in DeckService

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/service/DeckService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/service/DeckService.java
@@ -89,9 +89,6 @@ public class DeckService {
 
     public List<Deck> getDecksByVisibility(Visibility visibility) {
         List<Deck> publicDecksToBeReturned = this.deckRepository.findDeckByVisibility(visibility);
-        if (publicDecksToBeReturned.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Deck with that visibility not found!");
-        }
         return publicDecksToBeReturned;
     }
 


### PR DESCRIPTION
Fixes some weird problem when no decks are public then 404 not found gets returned